### PR TITLE
source-dataの更新完了後、APIデータを簡単に再ビルドできるようにする

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,7 @@
 name: GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "source-data"]
 	path = source-data
 	url = https://github.com/zengin-code/source-data.git
+	branch = master


### PR DESCRIPTION
長らく更新が止まっていたので原因を調べてみました。
source-dataの更新の仕組みがわかっていませんが、source-data側のactionでgithub.io側のworkflow_dispatchを呼び出せば、自動で更新されるようになると思います。